### PR TITLE
Enhance viewattendance functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewAttendanceCommand.java
@@ -3,11 +3,13 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.session.SessionStudentsContainsKeywordsPredicate;
+import seedu.address.model.session.Session;
 
 
 /**
@@ -21,14 +23,14 @@ public class ViewAttendanceCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe Alice";
 
-    private final SessionStudentsContainsKeywordsPredicate predicate;
+    private final Predicate<Session> predicate;
 
     /**
      * Creates a `ViewAttendanceCommand` to view attendance of student(s) listed.
      *
      * @param predicate The names of the student(s).
      */
-    public ViewAttendanceCommand(SessionStudentsContainsKeywordsPredicate predicate) {
+    public ViewAttendanceCommand(Predicate<Session> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/ViewAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewAttendanceCommandParser.java
@@ -1,14 +1,15 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SESSIONS;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.ViewAttendanceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Name;
+import seedu.address.model.session.Session;
 import seedu.address.model.session.SessionStudentsContainsKeywordsPredicate;
 
 /**
@@ -28,14 +29,14 @@ public class ViewAttendanceCommandParser implements Parser<ViewAttendanceCommand
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(
-                    MESSAGE_INVALID_COMMAND_FORMAT, ViewAttendanceCommand.MESSAGE_USAGE));
+        Predicate<Session> predicate = PREDICATE_SHOW_ALL_SESSIONS;
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String[] nameKeywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
+            predicate = new SessionStudentsContainsKeywordsPredicate(Arrays.asList(nameKeywords));
         }
 
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        String[] nameKeywords = name.toString().split("\\s+");
-        return new ViewAttendanceCommand(new SessionStudentsContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new ViewAttendanceCommand(predicate);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ViewAttendanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewAttendanceCommandParserTest.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SESSIONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,14 +45,8 @@ public class ViewAttendanceCommandParserTest {
     }
 
     @Test
-    public void parse_missingNamePrefix_throwsParseException() {
-        String invalidArgs = "John Doe";
-        assertThrows(ParseException.class, () -> parser.parse(invalidArgs));
-    }
-
-    @Test
-    public void parse_emptyName_throwsParseException() {
-        String invalidArgs = " n/";
-        assertThrows(ParseException.class, () -> parser.parse(invalidArgs));
+    public void parse_emptyArg_success() {
+        ViewAttendanceCommand expectedCommand = new ViewAttendanceCommand(PREDICATE_SHOW_ALL_SESSIONS);
+        assertParseSuccess(parser, "     ", expectedCommand);
     }
 }


### PR DESCRIPTION
Current ViewAttendance command does not show all sessions when no arguments are passed in.

This will allow the ViewAttendance command to show all sessions when user input is "viewattendance" without any name prefix and names.

Doing so will allow users to easily view all sessions