### PR TITLE
Email: change valid domain to u.nus.edu.sg

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -18,13 +18,13 @@ public class Email {
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
             + "2. This is followed by a '@' and then a domain name. As the app is currently developed for NUS teaching"
-            + "assistants, the domain name must be \"u.nus.ed.sg\".";
+            + "assistants, the domain name must be \"u.nus.edu\".";
 
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String NUS_DOMAIN = "u.nus.edu.sg";
+    private static final String NUS_DOMAIN = "u.nus.edu";
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + Pattern.quote(NUS_DOMAIN);
 
     public final String value;

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.regex.Pattern;
+
 /**
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
@@ -15,21 +17,15 @@ public class Email {
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
-            + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
-            + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+            + "2. This is followed by a '@' and then a domain name. As the app is currently developed for NUS teaching"
+            + "assistants, the domain name must be \"u.nus.ed.sg\".";
+
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    private static final String NUS_DOMAIN = "u.nus.edu.sg";
+    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + Pattern.quote(NUS_DOMAIN);
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -51,22 +51,22 @@ public class SampleDataUtil {
     public static final String VALID_GRADED_TEST_2 =
             "RA1:100 | RA2:100 | MidTerms:100 | Finals:100 | PE:100";
     public static final Person PERSON_ALEX = new Person(new Name("Alex Yeoh"), new Phone("87438807"),
-            new Email("alexyeoh@u.nus.edu.sg"), new TelegramHandle("alexYeohh"),
+            new Email("alexyeoh@u.nus.edu"), new TelegramHandle("alexYeohh"),
             getTagSet("friends"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_BERNICE = new Person(new Name("Bernice Yu"), new Phone("99272758"),
-            new Email("berniceyu@u.nus.edu.sg"), new TelegramHandle("berrynice123"),
+            new Email("berniceyu@u.nus.edu"), new TelegramHandle("berrynice123"),
             getTagSet("colleagues", "friends"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_CHARLOTTE = new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"),
-            new Email("charlotte@u.nus.edu.sg"), new TelegramHandle("charl0tt0"),
+            new Email("charlotte@u.nus.edu"), new TelegramHandle("charl0tt0"),
             getTagSet("neighbours"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_DAVID = new Person(new Name("David Li"), new Phone("91031282"),
-            new Email("lidavid@u.nus.edu.sg"), new TelegramHandle("goliathMyBestie"),
+            new Email("lidavid@u.nus.edu"), new TelegramHandle("goliathMyBestie"),
             getTagSet("family"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_IRFAN = new Person(new Name("Irfan Ibrahim"), new Phone("92492021"),
-            new Email("irfan@u.nus.edu.sg"), new TelegramHandle("nafri00"),
+            new Email("irfan@u.nus.edu"), new TelegramHandle("nafri00"),
             getTagSet("classmates"), getGradedTestSet(VALID_GRADED_TEST_2));
     public static final Person PERSON_ROY = new Person(new Name("Roy Balakrishnan"), new Phone("92624417"),
-            new Email("royb@u.nus.edu.sg"), new TelegramHandle("RoytheBoy"),
+            new Email("royb@u.nus.edu"), new TelegramHandle("RoytheBoy"),
             getTagSet("colleagues"), getGradedTestSet(VALID_GRADED_TEST_2));
 
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -51,22 +51,22 @@ public class SampleDataUtil {
     public static final String VALID_GRADED_TEST_2 =
             "RA1:100 | RA2:100 | MidTerms:100 | Finals:100 | PE:100";
     public static final Person PERSON_ALEX = new Person(new Name("Alex Yeoh"), new Phone("87438807"),
-            new Email("alexyeoh@example.com"), new TelegramHandle("alexYeohh"),
+            new Email("alexyeoh@u.nus.edu.sg"), new TelegramHandle("alexYeohh"),
             getTagSet("friends"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_BERNICE = new Person(new Name("Bernice Yu"), new Phone("99272758"),
-            new Email("berniceyu@example.com"), new TelegramHandle("berrynice123"),
+            new Email("berniceyu@u.nus.edu.sg"), new TelegramHandle("berrynice123"),
             getTagSet("colleagues", "friends"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_CHARLOTTE = new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"),
-            new Email("charlotte@example.com"), new TelegramHandle("charl0tt0"),
+            new Email("charlotte@u.nus.edu.sg"), new TelegramHandle("charl0tt0"),
             getTagSet("neighbours"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_DAVID = new Person(new Name("David Li"), new Phone("91031282"),
-            new Email("lidavid@example.com"), new TelegramHandle("goliathMyBestie"),
+            new Email("lidavid@u.nus.edu.sg"), new TelegramHandle("goliathMyBestie"),
             getTagSet("family"), getGradedTestSet(VALID_GRADED_TEST_1));
     public static final Person PERSON_IRFAN = new Person(new Name("Irfan Ibrahim"), new Phone("92492021"),
-            new Email("irfan@example.com"), new TelegramHandle("nafri00"),
+            new Email("irfan@u.nus.edu.sg"), new TelegramHandle("nafri00"),
             getTagSet("classmates"), getGradedTestSet(VALID_GRADED_TEST_2));
     public static final Person PERSON_ROY = new Person(new Name("Roy Balakrishnan"), new Phone("92624417"),
-            new Email("royb@example.com"), new TelegramHandle("RoytheBoy"),
+            new Email("royb@u.nus.edu.sg"), new TelegramHandle("RoytheBoy"),
             getTagSet("colleagues"), getGradedTestSet(VALID_GRADED_TEST_2));
 
 

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -3,7 +3,7 @@
     "name": "Valid Person",
     "phone": "9482424",
     "email": "hans@u.nus.edu",
-    "address": "4th street",
+    "telegramHandle" : "valid",
     "assignmentMap" : {
       "assignments" : {
         "Beyond the First Dimension" : {
@@ -127,7 +127,7 @@
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@u.nus.edu",
-    "address": "4th street",
+    "telegramHandle" : "valid",
     "assignmentMap" : {
       "assignments" : {
         "Beyond the First Dimension" : {

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Valid Person",
     "phone": "9482424",
-    "email": "hans@example.com",
+    "email": "hans@u.nus.edu.sg",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {
@@ -126,7 +126,7 @@
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
-    "email": "hans@example.com",
+    "email": "hans@u.nus.edu.sg",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Valid Person",
     "phone": "9482424",
-    "email": "hans@u.nus.edu.sg",
+    "email": "hans@u.nus.edu",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {
@@ -126,7 +126,7 @@
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
-    "email": "hans@u.nus.edu.sg",
+    "email": "hans@u.nus.edu",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
-    "email": "hans@example.com",
+    "email": "hans@u.nus.edu.sg",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -3,7 +3,7 @@
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
     "email": "hans@u.nus.edu",
-    "address": "4th street",
+    "telegramHandle" : "valid",
     "assignmentMap" : {
       "assignments" : {
         "Beyond the First Dimension" : {

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
-    "email": "hans@u.nus.edu.sg",
+    "email": "hans@u.nus.edu",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonConsultationListStorageTest/invalidDateConsultationListBook.json
+++ b/src/test/data/JsonConsultationListStorageTest/invalidDateConsultationListBook.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@u.nus.edu.sg",
+      "email" : "alexyeoh@u.nus.edu",
       "address" : "Blk 30 Geylang Street 29, #06-40",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -130,7 +130,7 @@
     }, {
       "name" : "Bernice Yu",
       "phone" : "99272758",
-      "email" : "berniceyu@u.nus.edu.sg",
+      "email" : "berniceyu@u.nus.edu",
       "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonConsultationListStorageTest/invalidDateConsultationListBook.json
+++ b/src/test/data/JsonConsultationListStorageTest/invalidDateConsultationListBook.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@example.com",
+      "email" : "alexyeoh@u.nus.edu.sg",
       "address" : "Blk 30 Geylang Street 29, #06-40",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -130,7 +130,7 @@
     }, {
       "name" : "Bernice Yu",
       "phone" : "99272758",
-      "email" : "berniceyu@example.com",
+      "email" : "berniceyu@u.nus.edu.sg",
       "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonConsultationListStorageTest/invalidDateConsultationListBook.json
+++ b/src/test/data/JsonConsultationListStorageTest/invalidDateConsultationListBook.json
@@ -6,7 +6,7 @@
       "name" : "Alex Yeoh",
       "phone" : "87438807",
       "email" : "alexyeoh@u.nus.edu",
-      "address" : "Blk 30 Geylang Street 29, #06-40",
+      "telegramHandle" : "valid",
       "tags" : [ "friends" ],
       "assignmentMap" : {
         "assignments" : {
@@ -131,7 +131,7 @@
       "name" : "Bernice Yu",
       "phone" : "99272758",
       "email" : "berniceyu@u.nus.edu",
-      "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
+      "telegramHandle" : "valid",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {
         "assignments" : {

--- a/src/test/data/JsonConsultationListStorageTest/invalidTimeConsultationListBook.json
+++ b/src/test/data/JsonConsultationListStorageTest/invalidTimeConsultationListBook.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@u.nus.edu.sg",
+      "email" : "alexyeoh@u.nus.edu",
       "address" : "Blk 30 Geylang Street 29, #06-40",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -130,7 +130,7 @@
     }, {
       "name" : "Bernice Yu",
       "phone" : "99272758",
-      "email" : "berniceyu@u.nus.edu.sg",
+      "email" : "berniceyu@u.nus.edu",
       "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonConsultationListStorageTest/invalidTimeConsultationListBook.json
+++ b/src/test/data/JsonConsultationListStorageTest/invalidTimeConsultationListBook.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@example.com",
+      "email" : "alexyeoh@u.nus.edu.sg",
       "address" : "Blk 30 Geylang Street 29, #06-40",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -130,7 +130,7 @@
     }, {
       "name" : "Bernice Yu",
       "phone" : "99272758",
-      "email" : "berniceyu@example.com",
+      "email" : "berniceyu@u.nus.edu.sg",
       "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonConsultationListStorageTest/invalidTimeConsultationListBook.json
+++ b/src/test/data/JsonConsultationListStorageTest/invalidTimeConsultationListBook.json
@@ -6,7 +6,7 @@
       "name" : "Alex Yeoh",
       "phone" : "87438807",
       "email" : "alexyeoh@u.nus.edu",
-      "address" : "Blk 30 Geylang Street 29, #06-40",
+      "telegramHandle" : "valid",
       "tags" : [ "friends" ],
       "assignmentMap" : {
         "assignments" : {
@@ -131,7 +131,7 @@
       "name" : "Bernice Yu",
       "phone" : "99272758",
       "email" : "berniceyu@u.nus.edu",
-      "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
+      "telegramHandle" : "valid",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {
         "assignments" : {

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Alice Pauline",
     "phone": "94351253",
-    "email": "alice@u.nus.edu.sg",
+    "email": "alice@u.nus.edu",
     "telegramHandle": "alicePaulding7",
     "tags": [ "friends" ],
     "assignmentMap" : {
@@ -127,7 +127,7 @@
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
-    "email": "pauline@u.nus.edu.sg",
+    "email": "pauline@u.nus.edu",
     "telegramHandle": "alicePaulding7",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Alice Pauline",
     "phone": "94351253",
-    "email": "alice@example.com",
+    "email": "alice@u.nus.edu.sg",
     "telegramHandle": "alicePaulding7",
     "tags": [ "friends" ],
     "assignmentMap" : {
@@ -127,7 +127,7 @@
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
-    "email": "pauline@example.com",
+    "email": "pauline@u.nus.edu.sg",
     "telegramHandle": "alicePaulding7",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -3,7 +3,7 @@
   "persons" : [ {
     "name" : "Alice Pauline",
     "phone" : "94351253",
-    "email" : "alice@u.nus.edu.sg",
+    "email" : "alice@u.nus.edu",
     "telegramHandle" : "alicePaulding7",
     "tags" : [ "friends" ],
     "assignmentMap" : {
@@ -128,7 +128,7 @@
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
-    "email" : "johnd@u.nus.edu.sg",
+    "email" : "johnd@u.nus.edu",
     "telegramHandle" : "Bensonson",
     "tags" : [ "owesMoney", "friends" ],
     "assignmentMap" : {
@@ -253,7 +253,7 @@
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
-    "email" : "heinz@u.nus.edu.sg",
+    "email" : "heinz@u.nus.edu",
     "telegramHandle" : "richcarlton1101",
     "tags" : [ ],
     "assignmentMap" : {
@@ -378,7 +378,7 @@
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
-    "email" : "cornelia@u.nus.edu.sg",
+    "email" : "cornelia@u.nus.edu",
     "telegramHandle" : "dantheman",
     "tags" : [ "friends" ],
     "assignmentMap" : {
@@ -503,7 +503,7 @@
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
-    "email" : "werner@u.nus.edu.sg",
+    "email" : "werner@u.nus.edu",
     "telegramHandle" : "AllieWithAnEButNoI",
     "tags" : [ ],
     "assignmentMap" : {
@@ -628,7 +628,7 @@
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
-    "email" : "lydia@u.nus.edu.sg",
+    "email" : "lydia@u.nus.edu",
     "telegramHandle" : "phi0na",
     "tags" : [ ],
     "assignmentMap" : {
@@ -753,7 +753,7 @@
   }, {
     "name" : "George Best",
     "phone" : "9482442",
-    "email" : "anna@u.nus.edu.sg",
+    "email" : "anna@u.nus.edu",
     "telegramHandle" : "georgeBes17",
     "tags" : [ ],
     "assignmentMap" : {

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -3,7 +3,7 @@
   "persons" : [ {
     "name" : "Alice Pauline",
     "phone" : "94351253",
-    "email" : "alice@example.com",
+    "email" : "alice@u.nus.edu.sg",
     "telegramHandle" : "alicePaulding7",
     "tags" : [ "friends" ],
     "assignmentMap" : {
@@ -128,7 +128,7 @@
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
-    "email" : "johnd@example.com",
+    "email" : "johnd@u.nus.edu.sg",
     "telegramHandle" : "Bensonson",
     "tags" : [ "owesMoney", "friends" ],
     "assignmentMap" : {
@@ -253,7 +253,7 @@
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
-    "email" : "heinz@example.com",
+    "email" : "heinz@u.nus.edu.sg",
     "telegramHandle" : "richcarlton1101",
     "tags" : [ ],
     "assignmentMap" : {
@@ -378,7 +378,7 @@
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
-    "email" : "cornelia@example.com",
+    "email" : "cornelia@u.nus.edu.sg",
     "telegramHandle" : "dantheman",
     "tags" : [ "friends" ],
     "assignmentMap" : {
@@ -503,7 +503,7 @@
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
-    "email" : "werner@example.com",
+    "email" : "werner@u.nus.edu.sg",
     "telegramHandle" : "AllieWithAnEButNoI",
     "tags" : [ ],
     "assignmentMap" : {
@@ -628,7 +628,7 @@
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
-    "email" : "lydia@example.com",
+    "email" : "lydia@u.nus.edu.sg",
     "telegramHandle" : "phi0na",
     "tags" : [ ],
     "assignmentMap" : {
@@ -753,7 +753,7 @@
   }, {
     "name" : "George Best",
     "phone" : "9482442",
-    "email" : "anna@example.com",
+    "email" : "anna@u.nus.edu.sg",
     "telegramHandle" : "georgeBes17",
     "tags" : [ ],
     "assignmentMap" : {

--- a/src/test/data/JsonSerializableAssignmentMapTest/invalidAssignmentMap.json
+++ b/src/test/data/JsonSerializableAssignmentMapTest/invalidAssignmentMap.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Valid Person Invalid AssignmentMap",
     "phone": "9482424",
-    "email": "hans@example.com",
+    "email": "hans@u.nus.edu.sg",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonSerializableAssignmentMapTest/invalidAssignmentMap.json
+++ b/src/test/data/JsonSerializableAssignmentMapTest/invalidAssignmentMap.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Valid Person Invalid AssignmentMap",
     "phone": "9482424",
-    "email": "hans@u.nus.edu.sg",
+    "email": "hans@u.nus.edu",
     "address": "4th street",
     "assignmentMap" : {
       "assignments" : {

--- a/src/test/data/JsonSerializableConsultationListTest/duplicateConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/duplicateConsultationList.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@example.com",
+      "email" : "alexyeoh@u.nus.edu.sg",
       "telegramHandle" : "alexYeohh",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -134,7 +134,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@example.com",
+      "email" : "alexyeoh@u.nus.edu.sg",
       "telegramHandle" : "alexYeohh",
       "tags" : [ "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonSerializableConsultationListTest/duplicateConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/duplicateConsultationList.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@u.nus.edu.sg",
+      "email" : "alexyeoh@u.nus.edu",
       "telegramHandle" : "alexYeohh",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -134,7 +134,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@u.nus.edu.sg",
+      "email" : "alexyeoh@u.nus.edu",
       "telegramHandle" : "alexYeohh",
       "tags" : [ "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonSerializableConsultationListTest/invalidConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/invalidConsultationList.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@u.nus.edu.sg",
+      "email" : "alexyeoh@u.nus.edu",
       "address" : "Blk 30 Geylang Street 29, #06-40",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -130,7 +130,7 @@
     }, {
       "name" : "Bernice Yu",
       "phone" : "99272758",
-      "email" : "berniceyu@u.nus.edu.sg",
+      "email" : "berniceyu@u.nus.edu",
       "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonSerializableConsultationListTest/invalidConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/invalidConsultationList.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Alex Yeoh",
       "phone" : "87438807",
-      "email" : "alexyeoh@example.com",
+      "email" : "alexyeoh@u.nus.edu.sg",
       "address" : "Blk 30 Geylang Street 29, #06-40",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -130,7 +130,7 @@
     }, {
       "name" : "Bernice Yu",
       "phone" : "99272758",
-      "email" : "berniceyu@example.com",
+      "email" : "berniceyu@u.nus.edu.sg",
       "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonSerializableConsultationListTest/invalidConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/invalidConsultationList.json
@@ -6,7 +6,7 @@
       "name" : "Alex Yeoh",
       "phone" : "87438807",
       "email" : "alexyeoh@u.nus.edu",
-      "address" : "Blk 30 Geylang Street 29, #06-40",
+      "telegramHandle" : "valid",
       "tags" : [ "friends" ],
       "assignmentMap" : {
         "assignments" : {
@@ -131,7 +131,7 @@
       "name" : "Bernice Yu",
       "phone" : "99272758",
       "email" : "berniceyu@u.nus.edu",
-      "address" : "Blk 30 Lorong 3 Serangoon Gardens, #07-18",
+      "telegramHandle" : "valid",
       "tags" : [ "colleagues", "friends" ],
       "assignmentMap" : {
         "assignments" : {

--- a/src/test/data/JsonSerializableConsultationListTest/typicalConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/typicalConsultationList.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Fiona Kunz",
       "phone" : "9482427",
-      "email" : "lydia@u.nus.edu.sg",
+      "email" : "lydia@u.nus.edu",
       "telegramHandle" : "phi0na",
       "tags" : [ ],
       "assignmentMap" : {
@@ -134,7 +134,7 @@
     "students" : [ {
       "name" : "Alice Pauline",
       "phone" : "94351253",
-      "email" : "alice@u.nus.edu.sg",
+      "email" : "alice@u.nus.edu",
       "telegramHandle" : "alicePaulding7",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -259,7 +259,7 @@
     }, {
       "name" : "George Best",
       "phone" : "9482442",
-      "email" : "anna@u.nus.edu.sg",
+      "email" : "anna@u.nus.edu",
       "telegramHandle" : "georgeBes17",
       "assignmentMap" : {
         "assignments" : {

--- a/src/test/data/JsonSerializableConsultationListTest/typicalConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/typicalConsultationList.json
@@ -387,7 +387,7 @@
     "students" : [ {
       "name" : "Alice Pauline",
       "phone" : "94351253",
-      "email" : "alice@example.com",
+      "email" : "alice@u.nus.edu",
       "telegramHandle" : "alicePaulding7",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -512,7 +512,7 @@
     }, {
       "name" : "George Best",
       "phone" : "9482442",
-      "email" : "anna@example.com",
+      "email" : "anna@u.nus.edu",
       "telegramHandle" : "georgeBes17",
       "assignmentMap" : {
         "assignments" : {
@@ -636,7 +636,7 @@
     }, {
       "name" : "Fiona Kunz",
       "phone" : "9482427",
-      "email" : "lydia@example.com",
+      "email" : "lydia@u.nus.edu",
       "telegramHandle" : "phi0na",
       "tags" : [ ],
       "assignmentMap" : {

--- a/src/test/data/JsonSerializableConsultationListTest/typicalConsultationList.json
+++ b/src/test/data/JsonSerializableConsultationListTest/typicalConsultationList.json
@@ -5,7 +5,7 @@
     "students" : [ {
       "name" : "Fiona Kunz",
       "phone" : "9482427",
-      "email" : "lydia@example.com",
+      "email" : "lydia@u.nus.edu.sg",
       "telegramHandle" : "phi0na",
       "tags" : [ ],
       "assignmentMap" : {
@@ -134,7 +134,7 @@
     "students" : [ {
       "name" : "Alice Pauline",
       "phone" : "94351253",
-      "email" : "alice@example.com",
+      "email" : "alice@u.nus.edu.sg",
       "telegramHandle" : "alicePaulding7",
       "tags" : [ "friends" ],
       "assignmentMap" : {
@@ -259,7 +259,7 @@
     }, {
       "name" : "George Best",
       "phone" : "9482442",
-      "email" : "anna@example.com",
+      "email" : "anna@u.nus.edu.sg",
       "telegramHandle" : "georgeBes17",
       "assignmentMap" : {
         "assignments" : {

--- a/src/test/data/JsonSerializableSessionListTest/duplicateSessionList.json
+++ b/src/test/data/JsonSerializableSessionListTest/duplicateSessionList.json
@@ -4,7 +4,7 @@
     "students": [{
       "name": "Alice Pauline",
       "phone": "94351253",
-      "email": "pauline@u.nus.edu.sg",
+      "email": "pauline@u.nus.edu",
       "telegramHandle": "alicePaulding7",
       "assignmentMap" : {
         "assignments" : {
@@ -134,7 +134,7 @@
         {
           "name": "Alice Pauline",
           "phone": "94351253",
-          "email": "pauline@u.nus.edu.sg",
+          "email": "pauline@u.nus.edu",
           "telegramHandle": "alicePaulding7",
           "assignmentMap" : {
             "assignments" : {

--- a/src/test/data/JsonSerializableSessionListTest/duplicateSessionList.json
+++ b/src/test/data/JsonSerializableSessionListTest/duplicateSessionList.json
@@ -4,7 +4,7 @@
     "students": [{
       "name": "Alice Pauline",
       "phone": "94351253",
-      "email": "pauline@example.com",
+      "email": "pauline@u.nus.edu.sg",
       "telegramHandle": "alicePaulding7",
       "assignmentMap" : {
         "assignments" : {
@@ -134,7 +134,7 @@
         {
           "name": "Alice Pauline",
           "phone": "94351253",
-          "email": "pauline@example.com",
+          "email": "pauline@u.nus.edu.sg",
           "telegramHandle": "alicePaulding7",
           "assignmentMap" : {
             "assignments" : {

--- a/src/test/data/JsonSerializableSessionListTest/typicalSessionList.json
+++ b/src/test/data/JsonSerializableSessionListTest/typicalSessionList.json
@@ -5,7 +5,7 @@
       {
         "name" : "Alice Pauline",
         "phone" : "94351253",
-        "email" : "alice@u.nus.edu.sg",
+        "email" : "alice@u.nus.edu",
         "telegramHandle" : "alicePaulding7",
         "tags" : [ "friends" ],
         "assignmentMap" : {
@@ -135,7 +135,7 @@
     "students" : [{
       "name" : "Benson Meier",
       "phone" : "98765432",
-      "email" : "johnd@u.nus.edu.sg",
+      "email" : "johnd@u.nus.edu",
       "telegramHandle" : "Bensonson",
       "tags" : [ "owesMoney", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonSerializableSessionListTest/typicalSessionList.json
+++ b/src/test/data/JsonSerializableSessionListTest/typicalSessionList.json
@@ -5,7 +5,7 @@
       {
         "name" : "Alice Pauline",
         "phone" : "94351253",
-        "email" : "alice@example.com",
+        "email" : "alice@u.nus.edu.sg",
         "telegramHandle" : "alicePaulding7",
         "tags" : [ "friends" ],
         "assignmentMap" : {
@@ -135,7 +135,7 @@
     "students" : [{
       "name" : "Benson Meier",
       "phone" : "98765432",
-      "email" : "johnd@example.com",
+      "email" : "johnd@u.nus.edu.sg",
       "telegramHandle" : "Bensonson",
       "tags" : [ "owesMoney", "friends" ],
       "assignmentMap" : {

--- a/src/test/data/JsonSessionListStorageTest/invalidAndValidSessionList.json
+++ b/src/test/data/JsonSessionListStorageTest/invalidAndValidSessionList.json
@@ -4,7 +4,7 @@
     "students": [{
       "name": "Valid Person",
       "phone": "9482424",
-      "email": "hans@example.com",
+      "email": "hans@u.nus.edu.sg",
       "address": "4th street",
       "assignmentMap" : {
         "assignments" : {

--- a/src/test/data/JsonSessionListStorageTest/invalidAndValidSessionList.json
+++ b/src/test/data/JsonSessionListStorageTest/invalidAndValidSessionList.json
@@ -4,7 +4,7 @@
     "students": [{
       "name": "Valid Person",
       "phone": "9482424",
-      "email": "hans@u.nus.edu.sg",
+      "email": "hans@u.nus.edu",
       "address": "4th street",
       "assignmentMap" : {
         "assignments" : {

--- a/src/test/data/JsonSessionListStorageTest/invalidAndValidSessionList.json
+++ b/src/test/data/JsonSessionListStorageTest/invalidAndValidSessionList.json
@@ -5,7 +5,7 @@
       "name": "Valid Person",
       "phone": "9482424",
       "email": "hans@u.nus.edu",
-      "address": "4th street",
+      "telegramHandle" : "valid",
       "assignmentMap" : {
         "assignments" : {
           "Beyond the First Dimension" : {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -52,8 +52,8 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
-    public static final String VALID_EMAIL_AMY = "amy@example.com";
-    public static final String VALID_EMAIL_BOB = "bob@example.com";
+    public static final String VALID_EMAIL_AMY = "amy@u.nus.edu.sg";
+    public static final String VALID_EMAIL_BOB = "bob@u.nus.edu.sg";
     public static final String VALID_TELEGRAM_HANDLE_AMY = "peterismybf";
     public static final String VALID_TELEGRAM_HANDLE_BOB = "bobbyrock00";
     public static final String VALID_TAG_HUSBAND = "husband";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -52,8 +52,8 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
-    public static final String VALID_EMAIL_AMY = "amy@u.nus.edu.sg";
-    public static final String VALID_EMAIL_BOB = "bob@u.nus.edu.sg";
+    public static final String VALID_EMAIL_AMY = "amy@u.nus.edu";
+    public static final String VALID_EMAIL_BOB = "bob@u.nus.edu";
     public static final String VALID_TELEGRAM_HANDLE_AMY = "peterismybf";
     public static final String VALID_TELEGRAM_HANDLE_BOB = "bobbyrock00";
     public static final String VALID_TAG_HUSBAND = "husband";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -34,7 +34,7 @@ public class ParserUtilTest {
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_TELEGRAM_HANDLE = "l_dinghan";
-    private static final String VALID_EMAIL = "rachel@u.nus.edu.sg";
+    private static final String VALID_EMAIL = "rachel@u.nus.edu";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -34,7 +34,7 @@ public class ParserUtilTest {
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_TELEGRAM_HANDLE = "l_dinghan";
-    private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_EMAIL = "rachel@u.nus.edu.sg";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -29,65 +29,62 @@ public class EmailTest {
         assertFalse(Email.isValidEmail(" ")); // spaces only
 
         // missing parts
-        assertFalse(Email.isValidEmail("@example.com")); // missing local part
-        assertFalse(Email.isValidEmail("peterjackexample.com")); // missing '@' symbol
+        assertFalse(Email.isValidEmail("@example.com")); // not the same as u.nus.edu.sg
+        assertFalse(Email.isValidEmail("peterjacku.nus.edu.sg")); // missing '@' symbol
         assertFalse(Email.isValidEmail("peterjack@")); // missing domain name
 
         // invalid parts
         assertFalse(Email.isValidEmail("peterjack@-")); // invalid domain name
-        assertFalse(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
-        assertFalse(Email.isValidEmail("peter jack@example.com")); // spaces in local part
-        assertFalse(Email.isValidEmail("peterjack@exam ple.com")); // spaces in domain name
-        assertFalse(Email.isValidEmail(" peterjack@example.com")); // leading space
-        assertFalse(Email.isValidEmail("peterjack@example.com ")); // trailing space
-        assertFalse(Email.isValidEmail("peterjack@@example.com")); // double '@' symbol
-        assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
-        assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
-        assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
-        assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
-        assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
-        assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
-        assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("peterjack@u.nu_s.edu.sg")); // underscore in domain name
+        assertFalse(Email.isValidEmail("peter jack@u.nus.edu.sg")); // spaces in local part
+        assertFalse(Email.isValidEmail("peterjack@u.nu s.edu.sg")); // spaces in domain name
+        assertFalse(Email.isValidEmail(" peterjack@u.nus.edu.sg")); // leading space
+        assertFalse(Email.isValidEmail("peterjack@u.nus.edu.sg ")); // trailing space
+        assertFalse(Email.isValidEmail("peterjack@@u.nus.edu.sg")); // double '@' symbol
+        assertFalse(Email.isValidEmail("peter@jack@u.nus.edu.sg")); // '@' symbol in local part
+        assertFalse(Email.isValidEmail("-peterjack@u.nus.edu.sg")); // local part starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack-@u.nus.edu.sg")); // local part ends with a hyphen
+        assertFalse(Email.isValidEmail("peter..jacku.nus.edu.sg")); // local part has two consecutive periods
+        assertFalse(Email.isValidEmail("peterjack@u.nu@s.edu.sg")); // '@' symbol in domain name
+        assertFalse(Email.isValidEmail("peterjack@.u.nus.edu.sg")); // domain name starts with a period
+        assertFalse(Email.isValidEmail("peterjack@u.nus.edu.sg.")); // domain name ends with a period
+        assertFalse(Email.isValidEmail("peterjack@-u.nus.edu.sg")); // domain name starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@u.nus.edu.sg-")); // domain name ends with a hyphen
+        assertFalse(Email.isValidEmail("123@145")); // numeric local part and domain name
 
         // valid email
-        assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
-        assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
-        assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
-        assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
-        assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
-        assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
-        assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
-        assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
-    }
-
-    @Test
-    public void isValidEmail_edgeCase_pass() {
-        assertTrue(Email.isValidEmail("A.B@cdomain.edu.fr")); // ends with .fr
-        assertTrue(Email.isValidEmail("iamsmart@bigbrain.io"));
-        assertTrue(Email.isValidEmail("someemail@stu.comp.nus.edu.sg")); // long domain labels
-        assertTrue(Email.isValidEmail("peterjack@example.a.b.c.e.d.f.g.com")); // long invalid domain labels
+        assertTrue(Email.isValidEmail("PeterJack_1190@u.nus.edu.sg")); // underscore in local part
+        assertTrue(Email.isValidEmail("PeterJack.1190@u.nus.edu.sg")); // period in local part
+        assertTrue(Email.isValidEmail("PeterJack+1190@u.nus.edu.sg")); // '+' symbol in local part
+        assertTrue(Email.isValidEmail("PeterJack-1190@u.nus.edu.sg")); // hyphen in local part
+        assertTrue(Email.isValidEmail("a1+be.d@u.nus.edu.sg")); // mixture of alphanumeric and special characters
+        assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@u.nus.edu.sg")); // long local part
+        assertTrue(Email.isValidEmail("e1234567@u.nus.edu.sg")); // more than one period in domain
     }
 
     @Test
     public void isValidEmail_edgeCase_fail() {
+        // invalid domain names
+        assertFalse(Email.isValidEmail("A.B@cdomain.edu.fr"));
+        assertFalse(Email.isValidEmail("iamsmart@bigbrain.io"));
+        assertFalse(Email.isValidEmail("someemail@stu.comp.nus.edu.sg"));
+        assertFalse(Email.isValidEmail("peterjack@example.a.b.c.e.d.f.g.com"));
         assertFalse(Email.isValidEmail("peterjack@example.com@")); // ends with @
         assertFalse(Email.isValidEmail("www.thisismyemail.com")); // http format
         assertFalse(Email.isValidEmail("user@[192.168.0.1].com")); // invalid char used
         assertFalse(Email.isValidEmail("user@example..com")); // multiple .
+
+        // edge cases symbols
+        assertFalse(Email.isValidEmail("A.B@u.nus_edu.sg")); // _ instead of .
+        assertFalse(Email.isValidEmail("A.B@u@nus.edu.sg")); // @ instead of .
     }
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@u.nus.edu.sg");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@u.nus.edu.sg")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -99,6 +96,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@u.nus.edu.sg")));
     }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -29,7 +29,7 @@ public class EmailTest {
         assertFalse(Email.isValidEmail(" ")); // spaces only
 
         // missing parts
-        assertFalse(Email.isValidEmail("@example.com")); // not the same as u.nus.edu
+        assertFalse(Email.isValidEmail("@u.nus.edu")); // missing local part
         assertFalse(Email.isValidEmail("peterjacku.nus.edu")); // missing '@' symbol
         assertFalse(Email.isValidEmail("peterjack@")); // missing domain name
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -29,37 +29,37 @@ public class EmailTest {
         assertFalse(Email.isValidEmail(" ")); // spaces only
 
         // missing parts
-        assertFalse(Email.isValidEmail("@example.com")); // not the same as u.nus.edu.sg
-        assertFalse(Email.isValidEmail("peterjacku.nus.edu.sg")); // missing '@' symbol
+        assertFalse(Email.isValidEmail("@example.com")); // not the same as u.nus.edu
+        assertFalse(Email.isValidEmail("peterjacku.nus.edu")); // missing '@' symbol
         assertFalse(Email.isValidEmail("peterjack@")); // missing domain name
 
         // invalid parts
         assertFalse(Email.isValidEmail("peterjack@-")); // invalid domain name
-        assertFalse(Email.isValidEmail("peterjack@u.nu_s.edu.sg")); // underscore in domain name
-        assertFalse(Email.isValidEmail("peter jack@u.nus.edu.sg")); // spaces in local part
-        assertFalse(Email.isValidEmail("peterjack@u.nu s.edu.sg")); // spaces in domain name
-        assertFalse(Email.isValidEmail(" peterjack@u.nus.edu.sg")); // leading space
-        assertFalse(Email.isValidEmail("peterjack@u.nus.edu.sg ")); // trailing space
-        assertFalse(Email.isValidEmail("peterjack@@u.nus.edu.sg")); // double '@' symbol
-        assertFalse(Email.isValidEmail("peter@jack@u.nus.edu.sg")); // '@' symbol in local part
-        assertFalse(Email.isValidEmail("-peterjack@u.nus.edu.sg")); // local part starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack-@u.nus.edu.sg")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jacku.nus.edu.sg")); // local part has two consecutive periods
-        assertFalse(Email.isValidEmail("peterjack@u.nu@s.edu.sg")); // '@' symbol in domain name
-        assertFalse(Email.isValidEmail("peterjack@.u.nus.edu.sg")); // domain name starts with a period
-        assertFalse(Email.isValidEmail("peterjack@u.nus.edu.sg.")); // domain name ends with a period
-        assertFalse(Email.isValidEmail("peterjack@-u.nus.edu.sg")); // domain name starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack@u.nus.edu.sg-")); // domain name ends with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@u.nu_s.edu")); // underscore in domain name
+        assertFalse(Email.isValidEmail("peter jack@u.nus.edu")); // spaces in local part
+        assertFalse(Email.isValidEmail("peterjack@u.nu s.edu")); // spaces in domain name
+        assertFalse(Email.isValidEmail(" peterjack@u.nus.edu")); // leading space
+        assertFalse(Email.isValidEmail("peterjack@u.nus.edu ")); // trailing space
+        assertFalse(Email.isValidEmail("peterjack@@u.nus.edu")); // double '@' symbol
+        assertFalse(Email.isValidEmail("peter@jack@u.nus.edu")); // '@' symbol in local part
+        assertFalse(Email.isValidEmail("-peterjack@u.nus.edu")); // local part starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack-@u.nus.edu")); // local part ends with a hyphen
+        assertFalse(Email.isValidEmail("peter..jacku.nus.edu")); // local part has two consecutive periods
+        assertFalse(Email.isValidEmail("peterjack@u.nu@s.edu")); // '@' symbol in domain name
+        assertFalse(Email.isValidEmail("peterjack@.u.nus.edu")); // domain name starts with a period
+        assertFalse(Email.isValidEmail("peterjack@u.nus.edu.")); // domain name ends with a period
+        assertFalse(Email.isValidEmail("peterjack@-u.nus.edu")); // domain name starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@u.nus.edu-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("123@145")); // numeric local part and domain name
 
         // valid email
-        assertTrue(Email.isValidEmail("PeterJack_1190@u.nus.edu.sg")); // underscore in local part
-        assertTrue(Email.isValidEmail("PeterJack.1190@u.nus.edu.sg")); // period in local part
-        assertTrue(Email.isValidEmail("PeterJack+1190@u.nus.edu.sg")); // '+' symbol in local part
-        assertTrue(Email.isValidEmail("PeterJack-1190@u.nus.edu.sg")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a1+be.d@u.nus.edu.sg")); // mixture of alphanumeric and special characters
-        assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@u.nus.edu.sg")); // long local part
-        assertTrue(Email.isValidEmail("e1234567@u.nus.edu.sg")); // more than one period in domain
+        assertTrue(Email.isValidEmail("PeterJack_1190@u.nus.edu")); // underscore in local part
+        assertTrue(Email.isValidEmail("PeterJack.1190@u.nus.edu")); // period in local part
+        assertTrue(Email.isValidEmail("PeterJack+1190@u.nus.edu")); // '+' symbol in local part
+        assertTrue(Email.isValidEmail("PeterJack-1190@u.nus.edu")); // hyphen in local part
+        assertTrue(Email.isValidEmail("a1+be.d@u.nus.edu")); // mixture of alphanumeric and special characters
+        assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@u.nus.edu")); // long local part
+        assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
     }
 
     @Test
@@ -67,7 +67,7 @@ public class EmailTest {
         // invalid domain names
         assertFalse(Email.isValidEmail("A.B@cdomain.edu.fr"));
         assertFalse(Email.isValidEmail("iamsmart@bigbrain.io"));
-        assertFalse(Email.isValidEmail("someemail@stu.comp.nus.edu.sg"));
+        assertFalse(Email.isValidEmail("someemail@stu.comp.nus.edu"));
         assertFalse(Email.isValidEmail("peterjack@example.a.b.c.e.d.f.g.com"));
         assertFalse(Email.isValidEmail("peterjack@example.com@")); // ends with @
         assertFalse(Email.isValidEmail("www.thisismyemail.com")); // http format
@@ -75,16 +75,16 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("user@example..com")); // multiple .
 
         // edge cases symbols
-        assertFalse(Email.isValidEmail("A.B@u.nus_edu.sg")); // _ instead of .
-        assertFalse(Email.isValidEmail("A.B@u@nus.edu.sg")); // @ instead of .
+        assertFalse(Email.isValidEmail("A.B@u.nus_edu")); // _ instead of .
+        assertFalse(Email.isValidEmail("A.B@u@nus.edu")); // @ instead of .
     }
 
     @Test
     public void equals() {
-        Email email = new Email("valid@u.nus.edu.sg");
+        Email email = new Email("valid@u.nus.edu");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@u.nus.edu.sg")));
+        assertTrue(email.equals(new Email("valid@u.nus.edu")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -96,6 +96,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@u.nus.edu.sg")));
+        assertFalse(email.equals(new Email("other.valid@u.nus.edu")));
     }
 }

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -69,9 +69,9 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and telegramHandle, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@u.nus.edu.sg", "Main", "Street"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withTelegramHandle("MainStreet").build()));
+                .withEmail("alice@u.nus.edu.sg").withTelegramHandle("MainStreet").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -69,9 +69,9 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and telegramHandle, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@u.nus.edu.sg", "Main", "Street"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@u.nus.edu", "Main", "Street"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@u.nus.edu.sg").withTelegramHandle("MainStreet").build()));
+                .withEmail("alice@u.nus.edu").withTelegramHandle("MainStreet").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -21,7 +21,7 @@ public class PersonBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_PHONE = "85355255";
-    public static final String DEFAULT_EMAIL = "amy@gmail.com";
+    public static final String DEFAULT_EMAIL = "amy@u.nus.edu.sg";
     public static final String DEFAULT_TELEGRAM_HANDLE = "l_dinghan";
 
     private Name name;

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -21,7 +21,7 @@ public class PersonBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_PHONE = "85355255";
-    public static final String DEFAULT_EMAIL = "amy@u.nus.edu.sg";
+    public static final String DEFAULT_EMAIL = "amy@u.nus.edu";
     public static final String DEFAULT_TELEGRAM_HANDLE = "l_dinghan";
 
     private Name name;

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,33 +26,33 @@ import seedu.address.model.util.SampleDataUtil;
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
-            .withTelegramHandle("alicePaulding7").withEmail("alice@example.com")
+            .withTelegramHandle("alicePaulding7").withEmail("alice@u.nus.edu.sg")
             .withPhone("94351253")
             .withTags("friends")
             .withGradedTest().build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withTelegramHandle("Bensonson")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@u.nus.edu.sg").withPhone("98765432")
             .withTags("owesMoney", "friends")
             .withGradedTest().build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withTelegramHandle("richcarlton1101")
+            .withEmail("heinz@u.nus.edu.sg").withTelegramHandle("richcarlton1101")
             .withGradedTest().build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withTelegramHandle("dantheman").withTags("friends")
+            .withEmail("cornelia@u.nus.edu.sg").withTelegramHandle("dantheman").withTags("friends")
             .withGradedTest().build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withTelegramHandle("AllieWithAnEButNoI").withGradedTest().build();
+            .withEmail("werner@u.nus.edu.sg").withTelegramHandle("AllieWithAnEButNoI").withGradedTest().build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withTelegramHandle("phi0na").withGradedTest().build();
+            .withEmail("lydia@u.nus.edu.sg").withTelegramHandle("phi0na").withGradedTest().build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withTelegramHandle("georgeBes17").withGradedTest().build();
+            .withEmail("anna@u.nus.edu.sg").withTelegramHandle("georgeBes17").withGradedTest().build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withTelegramHandle("hoonismyname").withGradedTest().build();
+            .withEmail("stefan@u.nus.edu.sg").withTelegramHandle("hoonismyname").withGradedTest().build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withTelegramHandle("idaho1202").withGradedTest().build();
+            .withEmail("hans@u.nus.edu.sg").withTelegramHandle("idaho1202").withGradedTest().build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,33 +26,33 @@ import seedu.address.model.util.SampleDataUtil;
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
-            .withTelegramHandle("alicePaulding7").withEmail("alice@u.nus.edu.sg")
+            .withTelegramHandle("alicePaulding7").withEmail("alice@u.nus.edu")
             .withPhone("94351253")
             .withTags("friends")
             .withGradedTest().build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withTelegramHandle("Bensonson")
-            .withEmail("johnd@u.nus.edu.sg").withPhone("98765432")
+            .withEmail("johnd@u.nus.edu").withPhone("98765432")
             .withTags("owesMoney", "friends")
             .withGradedTest().build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@u.nus.edu.sg").withTelegramHandle("richcarlton1101")
+            .withEmail("heinz@u.nus.edu").withTelegramHandle("richcarlton1101")
             .withGradedTest().build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@u.nus.edu.sg").withTelegramHandle("dantheman").withTags("friends")
+            .withEmail("cornelia@u.nus.edu").withTelegramHandle("dantheman").withTags("friends")
             .withGradedTest().build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@u.nus.edu.sg").withTelegramHandle("AllieWithAnEButNoI").withGradedTest().build();
+            .withEmail("werner@u.nus.edu").withTelegramHandle("AllieWithAnEButNoI").withGradedTest().build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@u.nus.edu.sg").withTelegramHandle("phi0na").withGradedTest().build();
+            .withEmail("lydia@u.nus.edu").withTelegramHandle("phi0na").withGradedTest().build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@u.nus.edu.sg").withTelegramHandle("georgeBes17").withGradedTest().build();
+            .withEmail("anna@u.nus.edu").withTelegramHandle("georgeBes17").withGradedTest().build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@u.nus.edu.sg").withTelegramHandle("hoonismyname").withGradedTest().build();
+            .withEmail("stefan@u.nus.edu").withTelegramHandle("hoonismyname").withGradedTest().build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@u.nus.edu.sg").withTelegramHandle("idaho1202").withGradedTest().build();
+            .withEmail("hans@u.nus.edu").withTelegramHandle("idaho1202").withGradedTest().build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)


### PR DESCRIPTION
Updated codebase and test files for strictly allowing only "u.nus.edu.sg" as valid domain for Email objects.


